### PR TITLE
Feature: Remove deployment of mock uniswap exchange/simplepos from migrations

### DIFF
--- a/migrations/2_test_migrations.js
+++ b/migrations/2_test_migrations.js
@@ -1,18 +1,5 @@
-const MockUniswapExchange = artifacts.require("MockUniswapExchange")
-const SimplePOS = artifacts.require("SimplePOS")
+const SimplePOSFactory = artifacts.require("SimplePOSFactory")
 
-module.exports = function (deployer, _, accounts) {
-  deployer.deploy(MockUniswapExchange).then(function () {
-    return deployer.deploy(
-      SimplePOS,
-      MockUniswapExchange.address,
-      "MyToken",
-      "simMTKN",
-      1,
-      500,
-      5000,
-      accounts[0],
-      { value: 1000000000000000000 }
-    )
-  })
+module.exports = function (deployer) {
+  deployer.deploy(SimplePOSFactory)
 }

--- a/migrations/3_deploy_factory.js
+++ b/migrations/3_deploy_factory.js
@@ -1,5 +1,0 @@
-const SimplePOSFactory = artifacts.require("SimplePOSFactory")
-
-module.exports = function (deployer) {
-  deployer.deploy(SimplePOSFactory)
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
       }
     },
     "@truffle/hdwallet-provider": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.2.0.tgz",
-      "integrity": "sha512-EPatDbyRuGbB/MLt9ZBokmtjyLjaNpuHfUIWuv4mQMrH1Nu82H5AAZYLh4Z1BZliDZpqB03a0yUMmK/4R0BN9g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.2.1.tgz",
+      "integrity": "sha512-EijX9JgcR3IaM1978ysHqJpObZNBgFWyBPzwy7YxMfWUaCp6PyM/g2w/b/DGmMHT56D56KVu+1PtHpEG0sbjtg==",
       "dev": true,
       "requires": {
         "@trufflesuite/web3-provider-engine": "15.0.13-1",
@@ -316,7 +316,7 @@
         "ethereum-protocol": "^1.0.1",
         "ethereumjs-tx": "^1.0.0",
         "ethereumjs-util": "^6.1.0",
-        "ethereumjs-wallet": "^0.6.3",
+        "ethereumjs-wallet": "^1.0.1",
         "source-map-support": "^0.5.19"
       }
     },
@@ -489,9 +489,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
-      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==",
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
       "dev": true
     },
     "@types/pbkdf2": {
@@ -934,9 +934,9 @@
       "dev": true
     },
     "bufferutil": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
-      "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
       "dev": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
@@ -1922,20 +1922,41 @@
       }
     },
     "ethereumjs-wallet": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
-      "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.1.tgz",
+      "integrity": "sha512-3Z5g1hG1das0JWU6cQ9HWWTY2nt9nXCcwj7eXVNAHKbo00XAZO8+NHlwdgXDWrL0SXVQMvTWN8Q/82DRH/JhPw==",
       "dev": true,
       "requires": {
         "aes-js": "^3.1.1",
         "bs58check": "^2.1.2",
         "ethereum-cryptography": "^0.1.3",
-        "ethereumjs-util": "^6.0.0",
+        "ethereumjs-util": "^7.0.2",
         "randombytes": "^2.0.6",
-        "safe-buffer": "^5.1.2",
-        "scryptsy": "^1.2.1",
+        "scrypt-js": "^3.0.1",
         "utf8": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.7.tgz",
+          "integrity": "sha512-vU5rtZBlZsgkTw3o6PDKyB8li2EgLavnAbsKcfsH2YhHH1Le+PP8vEiMnAnvgc1B6uMoaM5GDCrVztBw0Q5K9g==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "ethjs-unit": {
@@ -3769,18 +3790,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimic-response": {
@@ -4500,15 +4521,6 @@
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
       "dev": true
     },
-    "scryptsy": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-      "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
-      "dev": true,
-      "requires": {
-        "pbkdf2": "^3.0.3"
-      }
-    },
     "secp256k1": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
@@ -5034,9 +5046,9 @@
       "dev": true
     },
     "utf-8-validate": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
-      "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
+      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
       "dev": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
@@ -5169,9 +5181,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.11.tgz",
-          "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==",
+          "version": "12.19.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
+          "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
           "dev": true
         }
       }
@@ -5192,9 +5204,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.11.tgz",
-          "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==",
+          "version": "12.19.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
+          "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
           "dev": true
         }
       }
@@ -5397,9 +5409,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.11.tgz",
-          "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==",
+          "version": "12.19.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
+          "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/sche/simple-pos#readme",
   "devDependencies": {
     "@openzeppelin/contracts": "^3.3.0",
-    "@truffle/hdwallet-provider": "^1.2.0",
+    "@truffle/hdwallet-provider": "^1.2.1",
     "concurrently": "^5.3.0",
     "ganache-cli": "^6.12.1",
     "truffle-assertions": "^0.9.2",


### PR DESCRIPTION
As now the deployment is performed via a factory, I think we don't need to have it inside the migrations anymore. Also includes a small dependency bump

Factory on rinkeby: https://rinkeby.etherscan.io/address/0x2721FF699963CE97297F22b82fde933Eb33cF1B3#code